### PR TITLE
Gradle version for Backend clarified to be the same as Frontend; fix #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Course project of DevOps school
 List of required tools:
 <ul>
     <li>PostgreSQL 13</li>
-    <li>Gradle or gradlew</li>
+    <li>Gradle v6.7.1 or gradlew</li>
     <li>Java 8</li>
 </ul>
 

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Specified Gradle version, since it it listed in prerequisites. v6.x because it fails with recent versions. v6.7.1 - for consistency with the Frontend. Backend built fine with v6.7.1 for me.